### PR TITLE
update matching template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ opencv_apps_add_nodelet(discrete_fourier_transform discrete_fourier_transform/di
   # ./tutorial_code/Histograms_Matching/calcHist_Demo.cpp
   #  ./tutorial_code/Histograms_Matching/compareHist_Demo.cpp
   # ./tutorial_code/Histograms_Matching/EqualizeHist_Demo.cpp
-  # ./tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
+opencv_apps_add_nodelet(match_template match_template/match_template src/nodelet/match_template_nodelet.cpp) # ./tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
 
 # imagecodecs
   # ./tutorial_code/imgcodecs/GDAL_IO/gdal-image.cpp
@@ -330,8 +330,6 @@ endif()
 # https://github.com/opencv/opencv/blob/2.4/samples/cpp/video_dmtx.cpp
 # https://github.com/opencv/opencv/blob/2.4/samples/cpp/video_homography.cpp
 # https://github.com/opencv/opencv/blob/2.4/samples/cpp/videocapture_pvapi.cpp
-
-opencv_apps_add_nodelet(match_template match_template/match_template src/nodelet/match_template_nodelet.cpp)
 
 add_library(${PROJECT_NAME} SHARED
   src/nodelet/nodelet.cpp

--- a/cfg/MatchTemplate.cfg
+++ b/cfg/MatchTemplate.cfg
@@ -38,5 +38,13 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 gen.add("use_camera_info", bool_t, 0, "Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used.", False)
+match_type = gen.enum([gen.const("CV_TM_SQDIFF",        int_t,  0, "Sum of Ssquared Difference"),
+                       gen.const("CV_TM_SQDIFF_NORMED", int_t,  1, "Sum of Normalized Ssquared Difference"),
+                       gen.const("CV_TM_CCORR",         int_t,  2, "Correlation"),
+                       gen.const("CV_TM_CCORR_NORMED",  int_t,  3, "Normalized Correlation"),
+                       gen.const("CV_TM_CCOEFF",        int_t,  4, "Correlation of Coefficient"),
+                       gen.const("CV_TM_CCOEFF_NORMED", int_t,  5, "Normalized Correlation of Coefficient"),
+                   ], "An enum for Mathing Mehtods")
+gen.add("match_method", int_t, 0, "Matching Methods", 0, 0, 5, edit_method=match_type)
 
 exit(gen.generate(PACKAGE, "match_template", "MatchTemplate"))

--- a/launch/match_template.launch
+++ b/launch/match_template.launch
@@ -4,6 +4,8 @@
   <arg name="use_camera_info" default="false" doc="Indicates that the camera_info topic should be subscribed to to get the default input_frame_id. Otherwise the frame from the image message will be used." />
   <arg name="debug_view" default="false" doc="Specify whether the node displays a window to show edge image" />
   <arg name="match_method" default="0" doc="Matching method. 0:CV_TM_SQDIFF 1:CV_TM_SQDIFF_NORMED 2:CV_TM_CCORR 3:CV_TM_CCORR_NORMED 4:CV_TM_CCOEFF 5:CV_TM_CCOEFF_NORMED" />
+  <arg name="template_file" default="$(find opencv_apps)/template.png" doc="filename for template image"/>
+  <arg name="mask_file" default="$(find opencv_apps)/mask.png" doc="filename for mask image"/>
 
   <!-- match_template_nodelet.cpp -->
   <node name="$(arg node_name)" pkg="opencv_apps" type="match_template" output="screen">
@@ -12,7 +14,7 @@
     <param name="debug_view" value="$(arg debug_view)" />
     <param name="match_method" value="$(arg match_method)" />
     <param name="use_mask" value="false" />
-    <param name="template_file" value="$(find opencv_apps)/template.png" />
-    <param name="mask_file" value="$(find opencv_apps)/mask.png" />
+    <param name="template_file" value="$(arg template_file)" />
+    <param name="mask_file" value="$(arg mask_file)" />
   </node>
 </launch>

--- a/src/nodelet/match_template_nodelet.cpp
+++ b/src/nodelet/match_template_nodelet.cpp
@@ -63,7 +63,7 @@ namespace match_template
     image_transport::Subscriber img_sub_;
     image_transport::CameraSubscriber cam_sub_;
     ros::Publisher matched_val_pub_;
-    ros::Publisher msg_pub_;
+    ros::Publisher matched_rect_pub_;
 
     boost::shared_ptr < image_transport::ImageTransport > it_;
 
@@ -189,6 +189,18 @@ namespace match_template
           cv_bridge::CvImage (msg->header, sensor_msgs::image_encodings::MONO8, result).toImageMsg ();
         img_pub_.publish (out_img);
         matched_img_pub_.publish (match_img);
+
+        // Publish the result.
+        opencv_apps::RectArrayStamped matched_rect_msg;
+        matched_rect_msg.header = msg->header;
+        opencv_apps::Rect rect_msg;
+        rect_msg.x = matchLoc.x;
+        rect_msg.y = matchLoc.y;
+        rect_msg.width = templ_.cols;
+        rect_msg.height = templ_.rows;
+        matched_rect_msg.rects.push_back(rect_msg);
+        matched_rect_pub_.publish (matched_rect_msg);
+
         std_msgs::Float64 matched_val_msg;
         matched_val_msg.data = matchVal;
         matched_val_pub_.publish (matched_val_msg);
@@ -264,7 +276,7 @@ namespace match_template
       img_pub_ = advertiseImage (*pnh_, "image", 1);
       matched_img_pub_ = advertiseImage (*pnh_, "matched_image", 1);
       matched_val_pub_ = advertise< std_msgs::Float64 > (*pnh_, "matched_value", 1);
-      msg_pub_ = advertise < opencv_apps::RectArrayStamped > (*pnh_, "matched_rectangle", 1);
+      matched_rect_pub_ = advertise < opencv_apps::RectArrayStamped > (*pnh_, "matched_rectangle", 1);
 
       onInitPostProcess ();
     }

--- a/src/nodelet/match_template_nodelet.cpp
+++ b/src/nodelet/match_template_nodelet.cpp
@@ -72,12 +72,16 @@ namespace match_template
 
     bool debug_view_;
     int match_method_;
+#if (CV_MAJOR_VERSION >= 3 && CV_MINOR_VERSION >= 2) // mask is only supported since opencv 3.2 (https://github.com/opencv/opencv/pull/3554)
     bool use_mask_;
+#endif
 
       ros::Time prev_stamp_;
 
       cv::Mat templ_;
+#if (CV_MAJOR_VERSION >= 3 && CV_MINOR_VERSION >= 2)
       cv::Mat mask_;
+#endif
 
     void reconfigureCallback (Config & new_config, uint32_t level)
     {
@@ -128,11 +132,13 @@ namespace match_template
         //! [match_template]
         /// Do the Matching and Normalize
         bool method_accepts_mask = (match_method_ == CV_TM_SQDIFF || match_method_ == CV_TM_CCORR_NORMED);
+#if (CV_MAJOR_VERSION >= 3 && CV_MINOR_VERSION >= 2)
         if (use_mask_ && method_accepts_mask)
         {
           matchTemplate (frame, templ_, result, match_method_, mask_);
         }
         else
+#endif
         {
           matchTemplate (frame, templ_, result, match_method_);
         }
@@ -204,10 +210,15 @@ namespace match_template
 
       pnh_->param ("debug_view", debug_view_, false);
       pnh_->param ("match_method", match_method_, (int) CV_TM_SQDIFF);
+#if (CV_MAJOR_VERSION >= 3 && CV_MINOR_VERSION >= 2)
       pnh_->param ("use_mask", use_mask_, false);
-      std::string templ_file, mask_file;
+#endif
+      std::string templ_file;
       pnh_->param ("template_file", templ_file, std::string ("template.png"));
+#if (CV_MAJOR_VERSION >= 3 && CV_MINOR_VERSION >= 2)
+      std::string mask_file;
       pnh_->param ("mask_file", mask_file, std::string ("mask.png"));
+#endif
 
       NODELET_INFO ("template_file: %s", templ_file.c_str ());
 
@@ -215,10 +226,12 @@ namespace match_template
       {
         always_subscribe_ = true;
       }
+#if (CV_MAJOR_VERSION >= 3 && CV_MINOR_VERSION >= 2)
       if (use_mask_)
       {
         mask_ = imread (mask_file, cv::IMREAD_COLOR);
       }
+#endif
       if (templ_file.empty ())
       {
         NODELET_ERROR ("Cannot open template file %s", templ_file.c_str ());

--- a/src/nodelet/match_template_nodelet.cpp
+++ b/src/nodelet/match_template_nodelet.cpp
@@ -232,13 +232,12 @@ namespace match_template
         mask_ = imread (mask_file, cv::IMREAD_COLOR);
       }
 #endif
-      if (templ_file.empty ())
-      {
-        NODELET_ERROR ("Cannot open template file %s", templ_file.c_str ());
-        exit (0);
-      }
-      //templ_ = imread(templ_file, cv::IMREAD_COLOR);
       templ_ = imread (templ_file, cv::IMREAD_COLOR);
+      if (!templ_.data)
+      {
+        NODELET_ERROR ("Cannot open template file (%s)", templ_file.c_str ());
+        exit (-1);
+      }
 
       if (debug_view_)
       {

--- a/src/nodelet/match_template_nodelet.cpp
+++ b/src/nodelet/match_template_nodelet.cpp
@@ -122,13 +122,6 @@ namespace match_template
         int result_rows = frame.rows - templ_.rows + 1;
         cv::Mat result (result_rows, result_cols, CV_32FC1);
 
-        //-- Show template
-        if (debug_view_)
-        {
-          cv::imshow ("Template", templ_);
-          int c = cv::waitKey (1);
-        }
-
         //! [match_template]
         /// Do the Matching and Normalize
         bool method_accepts_mask = (match_method_ == CV_TM_SQDIFF || match_method_ == CV_TM_CCORR_NORMED);
@@ -169,6 +162,15 @@ namespace match_template
                    2, 8, 0);
         rectangle (result, matchLoc, cv::Point (matchLoc.x + templ_.cols, matchLoc.y + templ_.rows),
                    cv::Scalar::all (0), 2, 8, 0);
+
+        //-- Show template and result
+        if (debug_view_)
+        {
+          cv::imshow ("Template", templ_);
+          cv::imshow ("Soure Image", frame);
+          cv::imshow ("Result window", result);
+          int c = cv::waitKey (1);
+        }
 
         // Publish the image.
         sensor_msgs::Image::Ptr out_img =
@@ -239,11 +241,6 @@ namespace match_template
         exit (-1);
       }
 
-      if (debug_view_)
-      {
-        cv::imshow ("Match Template", templ_);
-        int c = cv::waitKey (1);
-      }
       prev_stamp_ = ros::Time (0, 0);
 
       reconfigure_server_ = boost::make_shared < dynamic_reconfigure::Server < Config > >(*pnh_);

--- a/src/nodelet/match_template_nodelet.cpp
+++ b/src/nodelet/match_template_nodelet.cpp
@@ -88,6 +88,10 @@ namespace match_template
     void reconfigureCallback (Config & new_config, uint32_t level)
     {
       config_ = new_config;
+      if ( match_method_ != config_.match_method ) {
+        match_method_ = config_.match_method;
+        NODELET_WARN_STREAM("Change Mathing Method to " << match_method_);
+      }
     }
 
     const std::string & frameWithDefault (const std::string & frame, const std::string & image_frame)

--- a/src/nodelet/match_template_nodelet.cpp
+++ b/src/nodelet/match_template_nodelet.cpp
@@ -160,7 +160,7 @@ namespace match_template
         }
         rectangle (frame, matchLoc, cv::Point (matchLoc.x + templ_.cols, matchLoc.y + templ_.rows), cv::Scalar::all (0),
                    2, 8, 0);
-        rectangle (result, matchLoc, cv::Point (matchLoc.x + templ_.cols, matchLoc.y + templ_.rows),
+        rectangle (result, cv::Point (matchLoc.x - templ_.cols/2, matchLoc.y - templ_.rows/2), cv::Point (matchLoc.x + templ_.cols/2, matchLoc.y + templ_.rows/2),
                    cv::Scalar::all (0), 2, 8, 0);
 
         //-- Show template and result

--- a/test/test-match_template.test
+++ b/test/test-match_template.test
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="gui" default="true" />
+  <node name="play_face_bag" pkg="rosbag" type="play" args="-l $(find opencv_apps)/test/face_detector_withface_test_diamondback.bag" />
+
+  <group ns="wide_stereo/left" >
+    <node name="image_proc" pkg="image_proc" type="image_proc" />
+    <node name="image_view" pkg="image_view" type="image_view" args="image:=image_rect_color" if="$(arg gui)" />
+
+    <!-- convex_hull.cpp -->
+    <include file="$(find opencv_apps)/launch/match_template.launch" >
+      <arg name="debug_view" value="$(arg gui)" />
+      <arg name="image" value="image_rect" />
+      <arg name="template_file" value="$(find opencv_apps)/test/template.png" />
+      <arg name="mask_file" value="" />
+    </include>
+
+    <!-- Test Codes -->
+    <node name="match_template_saver" pkg="image_view" type="image_saver" args="image:=match_template/image" >
+      <param name="filename_format" value="$(find opencv_apps)/test/match_template.png"/>
+    </node>
+    <param name="match_template_test/topic" value="match_template/matched_rectangle" />    <!-- opencv_apps/ContorArrayStamped -->
+    <test test-name="match_template_test" pkg="rostest" type="hztest" name="match_template_test" >
+      <param name="hz" value="20" />
+      <param name="hzerror" value="15" />
+      <param name="test_duration" value="5.0" /> 
+    </test>
+  </group>
+</launch>


### PR DESCRIPTION
905b3db add test/test-match-template.test
8682b42 match_template_nodelet.cpp: enable to select mathing method from rqt_reconfigure
3624f77 match_template_nodelet.cpp: publish result rectangle
35bcd77 match_template_nodelet.cpp: publish and display matched value
8205cad match_template_nodelet.cpp: fix show rectanlge on result image
e45deba show template and result
f38331d match_template_nodelet.cpp, show error when iread fails
082e094 CMakeLists.txt move opencv_apps_add_nodlet location
79f8ece matchTemplate: check opencv version, matchTemplate with mask is only suppreted >= 3.2


TODO: need to get template image from somewhere to run test....